### PR TITLE
Fix ZeroDivisionError and improve ManualQuery endpoint

### DIFF
--- a/backend/questionnaire_builder/routes.py
+++ b/backend/questionnaire_builder/routes.py
@@ -38,4 +38,5 @@ urlpatterns = [
     path('aimanagement/', views.AIEngineManagement.as_view(), name='AIEngineManagementList'),
     path("aimanagement/<uuid:uid>/", views.AIEngineManagement.as_view(), name="AIEngineManagementDetail"),
     path('modifyaiquery/', views.ModifyQueryAI.as_view(), name='ModifyAIQuery'),
+    path('manualquery/', views.ManualQuery.as_view(), name='ManualQuery'),
 ]


### PR DESCRIPTION
What I added:
I implemented a new backend endpoint /api/manualquery/ that generates workout plans using in-house logic instead of AI.
Details:
Endpoint: POST /api/manualquery/
Location: backend/questionnaire_builder/views/aiquery_views.py (new ManualQuery class)
Route: Added to backend/questionnaire_builder/routes.py
How it works:
Accepts questionnaire responses in the same format as the AI endpoint (array of {question, answers})
Maps answers to video categories using existing AnswerCategoryMapping logic
Ranks videos by category matches and builds a 3-day workout plan
Returns the same response structure as the AI endpoint (so the frontend renders it identically)
Includes "ai_engine_used": {"config_name": "Manual Logic", "model_name": "in-house"} to identify the source
Features:
Handles multiple input formats (question/answer by text or ID, single answer or array)
Falls back to available videos if no category mappings exist
Uses the same duration correction logic as the AI endpoint
Response format matches the AI endpoint for frontend compatibility
Use case: Provides an alternative to the AI engine for generating workout plans using the existing Logic Builder mappings.